### PR TITLE
Fixed typo in in IOS-XE-switch-rpc

### DIFF
--- a/vendor/cisco/xe/1771/Cisco-IOS-XE-switch-rpc.yang
+++ b/vendor/cisco/xe/1771/Cisco-IOS-XE-switch-rpc.yang
@@ -71,7 +71,7 @@ module Cisco-IOS-XE-switch-rpc {
           }
         }
         case stack-case {
-          container statck {
+          container stack {
             leaf port {
               description
                 "<1-2>  Stack port number to enable/disable";


### PR DESCRIPTION
There is a typo in the switch-rpc module.